### PR TITLE
1.1

### DIFF
--- a/lib/EntityContext.php
+++ b/lib/EntityContext.php
@@ -35,7 +35,7 @@ class EntityContext
 
         $interfaces = class_implements($providerType);
         if (!in_array(IEntityDataProvider::class, $interfaces)) {
-            throw new ClassException("{$providerType} must implements IEntityDataProvider inteface", 0, 1);
+            throw new ClassException("{$providerType} must implements IEntityDataProvider interface", 0, 1);
         }
 
         $provider = new $providerType($options->ConnectionString);

--- a/lib/Metadata/EntityType.php
+++ b/lib/Metadata/EntityType.php
@@ -144,7 +144,7 @@ class EntityType
         return $navigation;
     }
 
-    public function setTableName(string $name, string $schema = null): void
+    public function setTableName(string $name, ?string $schema = null): void
     {
         $this->tableName = $name;
         $this->schema = $schema;

--- a/lib/Migrations/MigrationHistory.php
+++ b/lib/Migrations/MigrationHistory.php
@@ -25,6 +25,7 @@ class MigrationHistory implements IEnumerable
     private string $table     = 'MigrationHistory';
     private array $migrations = [];
     private bool $existence   = false;
+    private string $version   = "0.0.0";
 
     public function __construct(EntityDatabase $database, MigrationAssembly $assembly)
     {
@@ -56,6 +57,14 @@ class MigrationHistory implements IEnumerable
         }
 
         $connection->close();
+
+        $json = json_decode(file_get_contents(dirname(__DIR__, 5). "/vendor/composer/installed.json"));
+        foreach ($json->packages as $package) {
+            if ($package->name == "devnet/orm") {
+                $this->version = $package->version;
+                break;
+            }
+        }
     }
 
     public function exists(): bool
@@ -86,7 +95,7 @@ class MigrationHistory implements IEnumerable
 
     public function getInsertScript(string $id): string
     {
-        $data = Operation::insertData($this->table, ['Id' => $id, 'Version' => '1.0.0']);
+        $data = Operation::insertData($this->table, ['Id' => $id, 'Version' => $this->version]);
         $migrationGenerator = new $this->database->DataProvider->MigrationGenerator;
         $migrationGenerator->visit($data);
 

--- a/lib/Migrations/MigrationHistory.php
+++ b/lib/Migrations/MigrationHistory.php
@@ -24,7 +24,6 @@ class MigrationHistory implements IEnumerable
     private EntityDatabase $database;
     private string $table     = 'MigrationHistory';
     private array $migrations = [];
-    private bool $existence   = false;
     private string $version   = "0.0.0";
 
     public function __construct(EntityDatabase $database, MigrationAssembly $assembly)
@@ -44,7 +43,6 @@ class MigrationHistory implements IEnumerable
         }
 
         if ($dbReader) {
-            $this->existence = true;
             while ($dbReader->read()) {
                 $id =  $dbReader->getValue("Id");
                 $migration = $assembly->where(fn ($migration) => $migration->Id == $id)->first();
@@ -69,7 +67,7 @@ class MigrationHistory implements IEnumerable
 
     public function exists(): bool
     {
-        return $this->existence;
+        return empty($this->migrations) ? false : true;
     }
 
     public function getSelectScript(): string

--- a/lib/Migrations/Migrator.php
+++ b/lib/Migrations/Migrator.php
@@ -122,7 +122,6 @@ class Migrator
                     }
                 }
             } else {
-                Console::writeLine("The database is already up to date.");
                 $count = 0;
             }
 

--- a/lib/Migrations/Operations/AlterTableOperation.php
+++ b/lib/Migrations/Operations/AlterTableOperation.php
@@ -41,7 +41,7 @@ class AlterTableOperation extends TableOperation
         return $primaryKey;
     }
 
-    public function dropPrimaryKey(string $constraint = null): void
+    public function dropPrimaryKey(?string $constraint = null): void
     {
         if ($constraint) {
             $primaryKey = new DropPrimaryKeyOperation($this->Name, []);
@@ -52,7 +52,7 @@ class AlterTableOperation extends TableOperation
         }
     }
 
-    public function addForeignKey(string $column, string $referencedTable, string $referencedColumn, string $constraint = null): void
+    public function addForeignKey(string $column, string $referencedTable, string $referencedColumn, ?string $constraint = null): void
     {
         $this->Constraints[] = new AddForeignKeyOperation($this->Name, $column, $referencedTable, $referencedColumn, $constraint);
     }

--- a/lib/Query/EntityQuery.php
+++ b/lib/Query/EntityQuery.php
@@ -29,7 +29,7 @@ class EntityQuery implements IQueryable
     private IQueryProvider $provider;
     private Expression $expression;
 
-    public function __construct(object $entityType, IQueryProvider $provider, Expression $expression = null)
+    public function __construct(object $entityType, IQueryProvider $provider, ?Expression $expression = null)
     {
         $this->entityType = $entityType;
         $this->provider   = $provider;

--- a/lib/Query/EntityQueryProvider.php
+++ b/lib/Query/EntityQueryProvider.php
@@ -23,7 +23,7 @@ class EntityQueryProvider implements IQueryProvider
         $this->database = $database;
     }
 
-    public function createQuery(object $entityType, Expression $expression = null): IQueryable
+    public function createQuery(object $entityType, ?Expression $expression = null): IQueryable
     {
         return new EntityQuery($entityType, $this, $expression);
     }

--- a/tools/MigrationGenerator.php
+++ b/tools/MigrationGenerator.php
@@ -50,6 +50,6 @@ class MigrationGenerator implements ICodeGenerator
         $this->content->appendLine('    }');
         $this->content->appendLine('}');
 
-        return [new CodeModel(date('Ymdhis') . '_' . $name . '.php', $this->content, $output)];
+        return [new CodeModel(date('YmdHis') . '_' . $name . '.php', $this->content, $output)];
     }
 }


### PR DESCRIPTION
Fix generating unique migration number
Make Generation of Migration history version dynamically from the ORM package version
Improve: checking the existence of migration history
Fix: remove unnecessary console message
Fix: deprecation notice of Implicitly marking parameters as nullable for PHP 8.4